### PR TITLE
[omnibus] fix geos package build error on RHEL-6

### DIFF
--- a/config/software/geos.rb
+++ b/config/software/geos.rb
@@ -9,6 +9,8 @@ relative_path "#{name}-#{version}"
 build do
   configure = ['./configure',
                "--prefix=#{install_dir}/embedded",
+               "CFLAGS=-O1",
+               "CXXFLAGS=-O1",
               ].join(' ')
   command configure
 


### PR DESCRIPTION
This PR fixes `geos` build issues due to missing `CFLAGS` config on RHEL-6, see https://github.com/CartoDB/omnibus-cartodb/issues/13 for more details.

Please, @hsato42 can you review it? thanks!
