### PR TITLE
[omnibus] fix geos package build error on RHEL-6

### DIFF
--- a/config/software/cartodb-rubygems.rb
+++ b/config/software/cartodb-rubygems.rb
@@ -1,5 +1,5 @@
 name 'cartodb-rubygems'
-default_version 'blp_sso'
+default_version 'ux_dev'
 
 source git: "https://github.com/bloomberg/cartodb",
        submodules: true

--- a/config/software/geos.rb
+++ b/config/software/geos.rb
@@ -9,6 +9,8 @@ relative_path "#{name}-#{version}"
 build do
   configure = ['./configure',
                "--prefix=#{install_dir}/embedded",
+               "CFLAGS=-O1",
+               "CXXFLAGS=-O1",
               ].join(' ')
   command configure
 

--- a/config/software/postgresql.rb
+++ b/config/software/postgresql.rb
@@ -16,7 +16,7 @@
 
 name "postgresql"
 # default_version "9.3.4"
-default_version "9.4.5"
+default_version "9.3.4"
 
 dependency "zlib"
 dependency "openssl"

--- a/config/software/postgresql.rb
+++ b/config/software/postgresql.rb
@@ -15,8 +15,8 @@
 #
 
 name "postgresql"
-# default_version "9.4.4"
-default_version "9.3.4"
+# default_version "9.3.4"
+default_version "9.4.5"
 
 dependency "zlib"
 dependency "openssl"
@@ -40,6 +40,10 @@ end
 
 version "9.4.4" do
   source md5: "1fe952c44ed26d7e6a335cf991a9c1c6"
+end
+
+version "9.4.5" do
+  source md5: "8b2e3472a8dc786649b4d02d02e039a0"
 end
 
 source url: "http://ftp.postgresql.org/pub/source/v#{version}/postgresql-#{version}.tar.bz2"


### PR DESCRIPTION
This PR fixes `geos` build issues due to missing `CFLAGS` config on RHEL-6, see https://github.com/CartoDB/omnibus-cartodb/issues/13 for more details.

Please, @hsato42 can you review it? thanks!
