### PR TITLE
[omnibus] fix boost source download URL

### DIFF
--- a/config/software/boost.rb
+++ b/config/software/boost.rb
@@ -4,7 +4,7 @@ default_version '1.56.0'
 
 us_version = version.gsub('.', '_')
 
-source url: "http://sourceforge.net/projects/boost/files/#{name}/#{version}/#{name}_#{us_version}.tar.bz2"
+source url: "http://downloads.sourceforge.net/project/boost/boost/#{version}/boost_#{us_version}.tar.bz2
 
 version "1.50.0" do
   source md5: "52dd00be775e689f55a987baebccc462"


### PR DESCRIPTION
SourceForge download URLs have changed.
