### PR TITLE
[omnibus] update to PostGIS 2.2.2

### DIFF
--- a/config/software/cartodb-postgis.rb
+++ b/config/software/cartodb-postgis.rb
@@ -1,8 +1,8 @@
 name 'cartodb-postgis'
-default_version '2.1.7'
+default_version '2.2.2'
 
 source url: "http://download.osgeo.org/postgis/source/postgis-#{version}.tar.gz",
-       md5: 'f35307c201caf04e7028f95b649cf6e7'
+       md5: 'ed42ad50405520bc1210bd4d3a872617'
 
 relative_path "postgis-#{version}"
 


### PR DESCRIPTION
PostGIS 2.2.2 is the last supported version at CartoDB.
