### PR TITLE
[omnibus] upgrade glib2 version

### DIFF
--- a/config/software/glib2.rb
+++ b/config/software/glib2.rb
@@ -1,5 +1,5 @@
 name "glib2"
-default_version "2.44.1"
+default_version "2.49.1"
 
 version "2.42.0" do
   source md5: "dc08133ca0e4ffd61bb626e8bc35eb3c"
@@ -7,6 +7,10 @@ end
 
 version "2.44.1" do
   source md5: "3894d2f4258749cb78c9a0b00af19db4"
+end
+
+version "2.49.1" do
+  source md5: "6012cb3e39325bccc7456a3fa13ed28e"
 end
 
 dependency "gettext"


### PR DESCRIPTION
`2.44.1` version is no longer available to download.
