### PR TITLE
[omnibus] fix pixman download url

### DIFF
--- a/config/software/pixman.rb
+++ b/config/software/pixman.rb
@@ -7,7 +7,7 @@ end
 
 dependency "libpng"
 
-source :url => "http://cairographics.org/releases/pixman-#{version}.tar.gz"
+source :url => "https://www.cairographics.org/releases/pixman-#{version}.tar.gz"
 
 relative_path "pixman-#{version}"
 


### PR DESCRIPTION
pixman download URL has changed, related: https://github.com/CartoDB/omnibus-cartodb/pull/47.
