### PR TITLE
Point gdal library to tag 'v1.11.1'

### DIFF
--- a/config/software/cartodb-gdal.rb
+++ b/config/software/cartodb-gdal.rb
@@ -1,5 +1,5 @@
 name 'cartodb-gdal'
-default_version '1.11.1'
+default_version 'v1.11.1'
 
 source git: "https://github.com/CartoDB/gdal.git"
 


### PR DESCRIPTION
Prior to this change gdal library configuration was pointing to a no longer existing
tag '1.11.1'. Change tag to 'v1.11.1', the new name of the same tag.